### PR TITLE
Release v1.2.0

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -3,32 +3,8 @@
 
 ### [1.2.0] - 2023-06-12
 
-#### Added
-
-- 
-
-#### Fixed
-
-- 
-
-#### Changed
-
-- 
-- - reduce duplicate logging messages (#14)
-- Release v1.1.0 (#13)
-- CI testing: drop node 6, add node 12
-- Merge pull request #8 from haraka/greenkeeper/update-to-node-10
-- Update to node 10 in .travis.yml
-- assure transaction still exists before trying to access txn.notes
-- Merge pull request #6 from haraka/release-1.0.4
-- tighten up LMTP routing condition
-- Merge pull request #5 from haraka/hook_mail
-- use correct name of mail hook
-- Merge pull request #4 from haraka/eslint-no-var
-- eslint no-var updates
-- Merge pull request #1 from haraka/qmd-get_mx
-- update tests too
-- updates for get/set
+- previously, would set a lmtp next_hop w/o setting q.wants=lmtp
+- refactored, added many tests
 
 
 ### [1.1.1] - 2022-11-29

--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,36 @@
 ### Unreleased
 
 
+### [1.2.0] - 2023-06-12
+
+#### Added
+
+- 
+
+#### Fixed
+
+- 
+
+#### Changed
+
+- 
+- - reduce duplicate logging messages (#14)
+- Release v1.1.0 (#13)
+- CI testing: drop node 6, add node 12
+- Merge pull request #8 from haraka/greenkeeper/update-to-node-10
+- Update to node 10 in .travis.yml
+- assure transaction still exists before trying to access txn.notes
+- Merge pull request #6 from haraka/release-1.0.4
+- tighten up LMTP routing condition
+- Merge pull request #5 from haraka/hook_mail
+- use correct name of mail hook
+- Merge pull request #4 from haraka/eslint-no-var
+- eslint no-var updates
+- Merge pull request #1 from haraka/qmd-get_mx
+- update tests too
+- updates for get/set
+
+
 ### [1.1.1] - 2022-11-29
 
 - ci: only publish when package.json has changes
@@ -52,3 +82,4 @@
 
 [1.1.0]: https://github.com/haraka/haraka-plugin-qmail-deliverable/releases/tag/1.1.0
 [1.1.1]: https://github.com/haraka/haraka-plugin-qmail-deliverable/releases/tag/1.1.1
+[1.2.0]: https://github.com/haraka/haraka-plugin-qmail-deliverable/releases/tag/1.2.0

--- a/Changes.md
+++ b/Changes.md
@@ -3,8 +3,11 @@
 
 ### [1.2.0] - 2023-06-12
 
-- previously, would set a lmtp next_hop w/o setting q.wants=lmtp
+- previously, would set next_hop=lmtp w/o setting q.wants=lmtp
 - refactored, added many tests
+- rename check_outbound -> check_mail_from
+- doc: added queue.wants & next_hop
+- chore: replace url.parse with new url.URL()
 
 
 ### [1.1.1] - 2022-11-29

--- a/Changes.md
+++ b/Changes.md
@@ -4,10 +4,13 @@
 ### [1.2.0] - 2023-06-12
 
 - previously, would set next_hop=lmtp w/o setting q.wants=lmtp
-- refactored, added many tests
-- rename check_outbound -> check_mail_from
+- feat: also route via LMTP for local recipients when relaying
+- cfg: rename check_outbound -> check_mail_from
+- cfg: declare check_mail_from as boolean
 - doc: added queue.wants & next_hop
+- chore: much refactoring to simplify do_qmd_response
 - chore: replace url.parse with new url.URL()
+- chore: added many tests
 
 
 ### [1.1.1] - 2022-11-29

--- a/README.md
+++ b/README.md
@@ -17,15 +17,15 @@ altering the contents of `config/qmail-deliverable.ini`
 
 * `port` (Default: 8998)
 
-* `check_mail_from`=true
+* `check_mail_from`= (Default: true)
 
 When `check_mail_from` is enabled, the MAIL FROM address is checked for deliverability. The deliverable status can be inspected by checking `transaction.notes.local_sender`.
 
-Domains can also specify MX routing by defining `queue` and `next_hop`.
+MX routing for individual domains can be set by defining `queue` and `next_hop`.
 
 * `queue`: a queue plugin (smtp_forward, qmail-queue), or lmtp. When `queue=lmtp`, if qmail-deliverable reports that the destination address is a mailbox (ie, not email list, forward, alias, etc.), then this plugin will configure the next_hop to be `lmtp://$host/` and will set up that route (via get_mx) so that outbound delivers the message to the mailbox via LMTP.
 
-* `next_hop`: a URL. Examples: `smtp://mx.example.com` and `lmtp://int.mx.example.com`
+* `next_hop`: a URL. Examples: `smtp://mx.example.com` and `lmtp://int.mx.example.com:24`
 
 
 ## Per-domain Configuration

--- a/README.md
+++ b/README.md
@@ -6,34 +6,36 @@
 
 A client for checking the deliverability of an email address against the [qmail-deliverabled](http://search.cpan.org/dist/Qmail-Deliverable/) daemon.
 
-On incoming messages (relaying=false), the RCPT TO address is validated.
-
-On outgoing messages (relaying=true) the MAIL FROM address is validated when
-the `check\_outbound` option is enabled.
+On incoming messages (relaying=false), validate the RCPT TO address.
 
 ## Configuration
 
 The host and port that qmail-deliverabled is listening on can be set by
-altering the contents of `config/rcpt_to.qmail_deliverable.ini`
+altering the contents of `config/qmail-deliverable.ini`
 
 * `host` (Default: localhost)
 
 * `port` (Default: 8998)
 
-* `check_outbound`=true
+* `check_mail_from`=true
 
-When `check_outbound` is enabled, and a connection has relay privileges, the
-MAIL FROM address is validated as deliverable.
+When `check_mail_from` is enabled, the MAIL FROM address is checked for deliverability. The deliverable status can be inspected by checking `transaction.notes.local_sender`.
+
+Domains can also specify MX routing by defining `queue` and `next_hop`.
+
+* `queue`: a queue plugin (smtp_forward, qmail-queue), or lmtp. When `queue=lmtp`, if qmail-deliverable reports that the destination address is a mailbox (ie, not email list, forward, alias, etc.), then this plugin will configure the next_hop to be `lmtp://$host/` and will set up that route (via get_mx) so that outbound delivers the message to the mailbox via LMTP.
+
+* `next_hop`: a URL. Examples: `smtp://mx.example.com` and `lmtp://int.mx.example.com`
+
 
 ## Per-domain Configuration
 
-Additionally, domains can each have their own configuration for connecting
-to qmail-deliverabled. The defaults are the same, so only the differences
+Domains can have their own configuration. The defaults are the same, so only the differences
 needs to be declared. Example:
 
     [example.com]
     host=192.168.0.1
-
+    
     [example2.com]
     host=192.168.0.2
 
@@ -45,4 +47,3 @@ needs to be declared. Example:
 [clim-url]: https://codeclimate.com/github/haraka/haraka-plugin-qmail-deliverable
 [npm-img]: https://nodei.co/npm/haraka-plugin-qmail-deliverable.png
 [npm-url]: https://www.npmjs.com/package/haraka-plugin-qmail-deliverable
-rcpt\_to.qmail\_deliverable

--- a/config/qmail-deliverable.ini
+++ b/config/qmail-deliverable.ini
@@ -1,7 +1,6 @@
 
-; When set to true, and a connection has relay privileges, verify that the
-; MAIL FROM address is deliverable.
-check_outbound=true
+; Check that the MAIL FROM address is deliverable.
+check_mail_from=true
 
 ; the IP address of the host running qmail_deliverable
 ; default: host=127.0.0.1
@@ -11,7 +10,7 @@ host=127.0.0.1
 port=8998
 
 ; if mail is delivered to a host other than the qmd host (above)
-; set it here in URI format
+; set it here as a URI
 ; next_hop=smtp://user:pass@[::127.0.0.35]:2500
 ; next_hop=lmtp://user:pass@127.0.0.1:24
 ; next_hop=lmtp://10.0.5.6
@@ -19,7 +18,7 @@ port=8998
 ; By default, relaying messages are delivered to outbound. Inbound are queued
 ; by the first queue plugin enabled. With this option, a specific queue
 ; can be specified for inbound recipients validated by qmd.
-; queue=[ outbound, smtp_forward, qmail-queue ]
+; queue=[ lmtp, outbound, smtp_forward, qmail-queue ]
 
 ;[example.com]
 ;host=127.0.0.10

--- a/index.js
+++ b/index.js
@@ -257,7 +257,7 @@ exports.hook_queue = function (next, connection) {
     switch (qw) {
         case 'lmtp':
         case 'outbound':
-            this.loginfo(`routing local recipient to outbound: ${qw}`);
+            this.loginfo(`routing to outbound: queue.wants=${qw}`);
             outbound.send_email(connection.transaction, next);
             break;
         default:
@@ -274,20 +274,20 @@ exports.hook_get_mx = function (next, hmail, domain) {
         priority: 0,
         port: 24,
         exchange: this.get_host(domain.toLowerCase()),
-    };
+    }
 
-    const nh = this.get_next_hop(domain.toLowerCase())
+    const nh = hmail.todo.notes.get('queue.next_hop')
     if (nh) {
-        const dest = url.parse(nh);
-        if (dest.hostname) mx.exchange = dest.hostname;
-        if (dest.port) mx.port = dest.port;
+        const dest = new url.URL(nh)
+        if (dest.hostname) mx.exchange = dest.hostname
+        if (dest.port) mx.port = dest.port
         if (dest.auth) {
-            mx.auth_type = 'plain';
-            mx.auth_user = dest.auth.split(':')[0];
-            mx.auth_pass = dest.auth.split(':')[1];
+            mx.auth_type = 'plain'
+            mx.auth_user = dest.auth.split(':')[0]
+            mx.auth_pass = dest.auth.split(':')[1]
         }
     }
 
-    this.logdebug(mx);
-    next(OK, mx);
+    this.logdebug(mx)
+    next(OK, mx)
 }

--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ exports.do_qmd_response = function (qmd_res, txn, rcpt, next) {
     }
 
     const domain = rcpt.host.toLowerCase();
-    let dom_cfg = this.cfg[domain] || this.cfg.main;
+    const dom_cfg = this.cfg[domain] || this.cfg.main;
 
     txn.notes.local_recipient=domain;
     txn.results.add(this, {pass: `rcpt.${dst_type}` });

--- a/index.js
+++ b/index.js
@@ -138,6 +138,7 @@ exports.do_qmd_response = function (qmd_res, connection, rcpt, next) {
 
     if (this.is_split(txn, queue, next_hop)) {
         if (dom_cfg?.split === 'defer') {
+            if (connection.relaying) return do_relaying(this, txn, next)
             return next(DENYSOFT, "Split transaction, retry soon");
         }
         txn.results.add(this, {msg: `split queue.wants=outbound`, emit: true})

--- a/index.js
+++ b/index.js
@@ -95,8 +95,8 @@ exports.hook_rcpt = function (next, connection, params) {
     // but Haraka has already validated for us by this point
     this.get_qmd_response(connection, rcpt, (err, qmd_res) => {
         if (err) {
-            txn.results.add(this, { err });
             if (connection.relaying) return do_relaying(this, txn, next)
+            txn.results.add(this, { err });
             return next(DENYSOFT, "error validating email address");
         }
         this.do_qmd_response(qmd_res, connection, rcpt, next)
@@ -109,16 +109,16 @@ exports.do_qmd_response = function (qmd_res, connection, rcpt, next) {
     const [r_code, dst_type] = qmd_res;
 
     if (r_code === undefined) {
-        txn.results.add(this, {err: `rcpt.${dst_type}`});
         if (connection.relaying) return do_relaying(this, txn, next)
+        txn.results.add(this, {err: `rcpt.${dst_type}`});
         return next();
     }
 
     if (r_code !== OK) {
+        if (connection.relaying) return do_relaying(this, txn, next)
         // no need to DENY[SOFT] for invalid addresses. If no rcpt_to.* plugin
         // returns OK, then the address is not accepted.
         txn.results.add(this, {msg: `rcpt.${dst_type}`});
-        if (connection.relaying) return do_relaying(this, txn, next)
         return next(CONT, dst_type);
     }
 

--- a/index.js
+++ b/index.js
@@ -16,22 +16,25 @@ exports.register = function () {
         outbound = this.haraka_require('outbound');
     }
 
-    if (this.cfg.main.check_outbound) {
+    if (this.cfg.main.check_outbound || this.cfg.main.check_mail_from) {
         this.register_hook('mail', 'check_mail_from');
     }
 }
 
 exports.load_qmd_ini = function () {
-    const plugin = this
-    plugin.cfg = plugin.config.get('qmail-deliverable.ini', function () {
-        plugin.load_qmd_ini()
+    this.cfg = this.config.get('qmail-deliverable.ini', {
+        booleans: [
+            '+main.check_mail_from',
+        ]
+    },
+    function () {
+        this.load_qmd_ini()
     })
 }
 
 exports.check_mail_from = function (next, connection, params) {
-    const plugin = this;
 
-    if (!plugin.cfg.main.check_outbound) return next();
+    if (!this.cfg.main.check_mail_from) return next();
 
     // determine if MAIL FROM domain is local
     const txn = connection.transaction;
@@ -39,169 +42,171 @@ exports.check_mail_from = function (next, connection, params) {
     const email = params[0].address();
     if (!email) {
         // likely an IP with relaying permission
-        txn.results.add(plugin, { skip: 'mail_from.null', emit: true });
+        txn.results.add(this, { skip: 'mail_from.null', emit: true });
         return next();
     }
 
     const domain = params[0].host.toLowerCase();
 
-    plugin.get_qmd_response(connection, domain, email, (err, qmd_r) => {
+    this.get_qmd_response(connection, params[0], (err, qmd_r) => {
         if (err) {
-            txn.results.add(plugin, {err});
+            txn.results.add(this, {err});
             return next(DENYSOFT, err);
         }
 
         // the MAIL FROM sender is verified as a local address
         if (qmd_r[0] === OK) {
-            txn.results.add(plugin, { pass: `mail_from.${qmd_r[1]}` });
+            txn.results.add(this, { pass: `mail_from.${qmd_r[1]}` });
             txn.notes.local_sender=domain;
             return next();
         }
 
         if (qmd_r[0] === undefined) {
-            txn.results.add(plugin, { err: `mail_from.${qmd_r[1]}` });
+            txn.results.add(this, { err: `mail_from.${qmd_r[1]}` });
             return next();
         }
 
-        txn.results.add(plugin, { msg: `mail_from.${qmd_r[1]}` });
-        return next(CONT, `mail_from.${qmd_r[1]}`);
+        txn.results.add(this, { msg: `mail_from.${qmd_r[1]}` });
+        next(CONT, `mail_from.${qmd_r[1]}`);
     })
 }
 
-exports.get_next_hop = function (dom_cfg, queue_wanted) {
-
-    if (dom_cfg.next_hop) return dom_cfg.next_hop;
-
-    switch (queue_wanted) {
-        case 'lmtp':
-            return (`lmtp://${dom_cfg.host}`);
-        default:
-            return (`smtp://${dom_cfg.host}`);
-    }
-}
-
-exports.set_queue = function (connection, queue_wanted, domain) {
-    const plugin = this;
-
-    let dom_cfg = plugin.cfg[domain];
-    if (dom_cfg === undefined) dom_cfg = plugin.cfg.main;
-
-    if (!queue_wanted) queue_wanted = dom_cfg.queue;
-    if (!queue_wanted) return true;
-
-    const txn = connection.transaction;
-    if (!txn) return;
-    const next_hop = plugin.get_next_hop(dom_cfg, queue_wanted);
-
-    if (!txn.notes.get('queue.wants')) {
-        txn.results.add(plugin, {msg: `setting queue.wants=${queue_wanted}, ${next_hop}`})
-        txn.notes.set('queue.wants', queue_wanted);
-        txn.notes.set('queue.next_hop', next_hop);
-        return true;
-    }
-
-    // multiple recipients with same destination
-    if (txn.notes.get('queue.wants') === queue_wanted &&
-        txn.notes.get('queue.next_hop') === next_hop) {
-        return true;
-    }
-
-    // multiple recipients with different forward host, soft deny
-    return false;
-}
-
 exports.hook_rcpt = function (next, connection, params) {
-    const plugin = this;
     const txn = connection.transaction;
 
     const rcpt = params[0];
-    const domain = rcpt.host.toLowerCase();
-    let dom_cfg = plugin.cfg[domain];
-    if (dom_cfg === undefined) dom_cfg = plugin.cfg.main;
+
+    // a client with relaying privileges, any RCPT is acceptable.
+    if (connection.relaying) {
+        txn.results.add(this, {pass: `relaying${txn.notes.local_sender ? ' local sender' : ''}`});
+        txn.notes.set('queue.wants', 'outbound');
+        return next(OK);
+    }
 
     // Qmail::Deliverable::Client does a rfc2822 "atext" test
     // but Haraka has already validated for us by this point
-    plugin.get_qmd_response(connection, domain, rcpt.address(), (err, qmd_r) => {
+    this.get_qmd_response(connection, rcpt, (err, qmd_res) => {
         if (err) {
-            txn.results.add(plugin, { err });
+            txn.results.add(this, { err });
             return next(DENYSOFT, "error validating email address");
         }
-
-        const [r_code, dst_type] = qmd_r;
-
-        // a client with relaying privileges is sending from a local domain.
-        // Any RCPT is acceptable.
-        if (connection.relaying && txn.notes.local_sender) {
-            txn.results.add(plugin, {pass: "relaying local_sender"});
-            plugin.set_queue(connection, 'outbound');
-            const q = txn.notes.get('queue.wants');
-            if (q) connection.loginfo(`queue: ${q}`);
-            return next(OK);
-        }
-
-        if (r_code === OK) {
-            txn.notes.local_recipient=domain;
-            txn.results.add(plugin, {pass: `rcpt.${dst_type}`, emit: true });
-            let queue = dom_cfg.queue;
-            if (dst_type === 'vpopmail dir' && dom_cfg.next_hop) {
-                if (/^lmtp/.test(dom_cfg.next_hop)) queue = 'lmtp';
-            }
-            if (plugin.set_queue(connection, queue, domain)) {
-                return next(OK);
-            }
-            return next(DENYSOFT, "Split transaction, retry soon");
-        }
-
-        if (r_code === undefined) {
-            txn.results.add(plugin, {err: `rcpt.${  dst_type}`});
-            return next();
-        }
-
-        // no need to DENY[SOFT] for invalid addresses. If no rcpt_to.* plugin
-        // returns OK, then the address is not accepted.
-        txn.results.add(plugin, {msg: `rcpt.${  dst_type}`});
-        return next(CONT, dst_type);
-    });
+        this.do_qmd_response(qmd_res, txn, rcpt, next)
+    })
 }
 
-exports.get_qmd_response = function (connection, domain, email, cb) {
+exports.do_qmd_response = function (qmd_res, txn, rcpt, next) {
+
+    const [r_code, dst_type] = qmd_res;
+
+    if (r_code === undefined) {
+        txn.results.add(this, {err: `rcpt.${dst_type}`});
+        return next();
+    }
+
+    if (r_code !== OK) {
+        // no need to DENY[SOFT] for invalid addresses. If no rcpt_to.* plugin
+        // returns OK, then the address is not accepted.
+        txn.results.add(this, {msg: `rcpt.${dst_type}`});
+        return next(CONT, dst_type);
+    }
+
+    const domain = rcpt.host.toLowerCase();
+    let dom_cfg = this.cfg[domain] || this.cfg.main;
+
+    txn.notes.local_recipient=domain;
+    txn.results.add(this, {pass: `rcpt.${dst_type}` });
+
+    let queue = this.get_queue(domain)
+    let next_hop = this.get_next_hop(domain, queue)
+
+    if (dst_type === 'vpopmail dir' && next_hop) {
+        if (/^lmtp/.test(next_hop)) queue = 'lmtp';
+        next_hop = this.get_next_hop(domain, queue)
+    }
+
+    if (this.is_split(txn, queue, next_hop)) {
+        if (dom_cfg?.split === 'defer') {
+            return next(DENYSOFT, "Split transaction, retry soon");
+        }
+        txn.results.add(this, {msg: `split queue.wants=outbound`, emit: true})
+        txn.notes.set('queue.wants', 'outbound');
+        delete txn.notes?.queue?.next_hop;
+    }
+    else {
+        if (!txn.notes.get('queue.wants')) {
+            txn.results.add(this, {msg: `queue.wants=${queue}, next_hop=${next_hop}`, emit: true})
+            txn.notes.set('queue.wants', queue);
+            txn.notes.set('queue.next_hop', next_hop);
+        }
+    }
+
+    next(OK);
+}
+
+exports.is_split = function (txn, queue, next_hop) {
+
+    if (txn.rcpt_to.length > 1) return true;
+
+    const qw = txn.notes.get('queue.wants')
+    if (qw && qw !== queue) return true
+
+    const qnh = txn.notes.get('queue.next_hop')
+    if (qnh && qnh !== next_hop) return true
+
+    return false  // identical destinations
+}
+
+exports.get_next_hop = function (domain, queue) {
+    const hop = this.cfg[domain]?.next_hop || this.cfg.main.next_hop
+    if (hop) return hop
+    return `${queue === 'lmtp' ? 'lmtp' : 'smtp'}://${this.get_host(domain)}`
+}
+
+exports.get_queue = function (domain) {
+    // lmtp, outbound, smtp_forward, qmail-queue
+    return this.cfg[domain]?.queue || this.cfg.main.queue;
+}
+
+exports.get_host = function (domain) {
+    return this.cfg[domain]?.host || this.cfg.main.host || '127.0.0.1'
+}
+
+exports.get_port = function (domain) {
+    return this.cfg[domain]?.port || this.cfg.main.port || 8998
+}
+
+exports.get_qmd_response = function (connection, addr, cb) {
     const plugin = this;
 
-    let cfg = plugin.cfg[domain];
-    if (cfg === undefined) cfg = plugin.cfg.main;
+    const domain = addr.host.toLowerCase()
+    const email  = addr.address()
 
     const options = {
         method: 'get',
-        host: cfg.host || '127.0.0.1',
-        port: cfg.port || 8998,
+        host: plugin.get_host(domain),
+        port: plugin.get_port(domain),
     };
 
-    // redundant
-    // connection.transaction.results.add(plugin, {
-    //     msg: "sock: " + options.host + ':' + options.port
-    // });
-
     connection.logdebug(plugin, `checking ${email}`);
-    options.path = `/qd1/deliverable?${  querystring.escape(email)}`;
+    options.path = `/qd1/deliverable?${querystring.escape(email)}`;
     // connection.logdebug(plugin, 'PATH: ' + options.path);
     http.get(options, function (res) {
-        connection.logprotocol(plugin, `STATUS: ${  res.statusCode}`);
-        connection.logprotocol(plugin, `HEADERS: ${  JSON.stringify(res.headers)}`);
+        connection.logprotocol(plugin, `STATUS: ${res.statusCode}`);
+        connection.logprotocol(plugin, `HEADERS: ${JSON.stringify(res.headers)}`);
         res.setEncoding('utf8');
         res.on('data', function (chunk) {
-            connection.logprotocol(plugin, `BODY: ${  chunk}`);
+            connection.logprotocol(plugin, `BODY: ${chunk}`);
             const hexnum = new Number(chunk).toString(16);
-            const arr = plugin.check_qmd_response(connection, hexnum);
+            const arr = plugin.decode_qmd_response(connection, hexnum);
             connection.logdebug(plugin, arr[1]);
             cb(undefined, arr);
-
         });
     }).on('error', cb)
 }
 
-exports.check_qmd_response = function (connection, hexnum) {
-    const plugin = this;
-    connection.logprotocol(plugin,`HEXRV: ${  hexnum}` );
+exports.decode_qmd_response = function (connection, hexnum) {
+
+    connection.logprotocol(this,`HEXRV: ${  hexnum}` );
 
     switch (hexnum) {
         case '11':
@@ -248,30 +253,32 @@ exports.check_qmd_response = function (connection, hexnum) {
 
 exports.hook_queue = function (next, connection) {
 
-    const wants = connection.transaction.notes.get('queue.wants');
-    if (wants !== 'lmtp') return next();
-
-    this.logdebug('QMD routing to outbound');
-    outbound.send_email(connection.transaction, next);
+    const qw = connection.transaction.notes.get('queue.wants')
+    switch (qw) {
+        case 'lmtp':
+        case 'outbound':
+            this.loginfo(`routing local recipient to outbound: ${qw}`);
+            outbound.send_email(connection.transaction, next);
+            break;
+        default:
+            next(); // do nothing
+    }
 }
 
 exports.hook_get_mx = function (next, hmail, domain) {
-    const plugin = this;
 
     if (hmail.todo.notes.get('queue.wants') !== 'lmtp') return next();
-
-    let cfg = plugin.cfg[domain.toLowerCase()];
-    if (cfg === undefined) cfg = plugin.cfg.main;
 
     const mx = {
         using_lmtp: true,
         priority: 0,
         port: 24,
-        exchange: cfg.host,
+        exchange: this.get_host(domain.toLowerCase()),
     };
 
-    if (cfg.next_hop) {
-        const dest = url.parse(cfg.next_hop);
+    const nh = this.get_next_hop(domain.toLowerCase())
+    if (nh) {
+        const dest = url.parse(nh);
         if (dest.hostname) mx.exchange = dest.hostname;
         if (dest.port) mx.port = dest.port;
         if (dest.auth) {
@@ -281,6 +288,6 @@ exports.hook_get_mx = function (next, hmail, domain) {
         }
     }
 
-    plugin.logdebug(mx);
-    return next(OK, mx);
+    this.logdebug(mx);
+    next(OK, mx);
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haraka-plugin-qmail-deliverable",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Haraka plugin that validates recipients against Qmail::Deliverable",
   "main": "index.js",
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -262,7 +262,7 @@ describe('decode_qmd_response', function () {
     })
 })
 
-describe.only('hook_get_mx', function () {
+describe('hook_get_mx', function () {
     beforeEach(_set_up_cfg)
 
     it('returns nothing unless queue.wants=lmtp', function (done) {
@@ -284,10 +284,10 @@ describe.only('hook_get_mx', function () {
         this.plugin.hook_get_mx((code, mx) => {
             assert.equal(code, OK)
             assert.deepEqual(mx, {
-                  exchange: '127.0.0.1',
-                  port: 24,
-                  priority: 0,
-                  using_lmtp: true
+                exchange: '127.0.0.1',
+                port: 24,
+                priority: 0,
+                using_lmtp: true
             })
             done()
         }, hmail, 'example.com')
@@ -302,13 +302,12 @@ describe.only('hook_get_mx', function () {
         this.plugin.hook_get_mx((code, mx) => {
             assert.equal(code, OK)
             assert.deepEqual(mx, {
-                  exchange: '127.1.1.1',
-                  port: 23,
-                  priority: 0,
-                  using_lmtp: true
+                exchange: '127.1.1.1',
+                port: 23,
+                priority: 0,
+                using_lmtp: true
             })
             done()
         }, hmail, 'example.com')
     })
-
 })

--- a/test/index.js
+++ b/test/index.js
@@ -67,7 +67,7 @@ describe('do_qmd_response', function () {
         this.plugin.cfg = {
             main: { host: '1.2.3.4' },
         }
-        this.plugin.do_qmd_response([OK, 'vpopmail dir'], this.connection.transaction, rcpt, (code, msg) => {
+        this.plugin.do_qmd_response([OK, 'vpopmail dir'], this.connection, rcpt, (code, msg) => {
             assert.equal(this.connection.transaction.notes.get('queue.wants'), undefined);
             assert.equal(this.connection.transaction.notes.get('queue.next_hop'), 'smtp://1.2.3.4');
             done()
@@ -78,7 +78,7 @@ describe('do_qmd_response', function () {
         this.plugin.cfg = {
             main: { host: '1.2.3.4' },
         }
-        this.plugin.do_qmd_response([OK, 'vpopmail alias'], this.connection.transaction, rcpt, (code, msg) => {
+        this.plugin.do_qmd_response([OK, 'vpopmail alias'], this.connection, rcpt, (code, msg) => {
             assert.equal(this.connection.transaction.notes.get('queue.wants'), undefined);
             assert.equal(this.connection.transaction.notes.get('queue.next_hop'), 'smtp://1.2.3.4');
             done()
@@ -87,7 +87,7 @@ describe('do_qmd_response', function () {
 
     it('example.com: queue=undefined, dir', function (done) {
         this.plugin.cfg['example.com'] = { host: '1.2.3.4' }
-        this.plugin.do_qmd_response([OK, 'vpopmail dir'], this.connection.transaction, rcpt, (code, msg) => {
+        this.plugin.do_qmd_response([OK, 'vpopmail dir'], this.connection, rcpt, (code, msg) => {
             assert.equal(this.connection.transaction.notes.get('queue.wants'), undefined);
             assert.equal(this.connection.transaction.notes.get('queue.next_hop'), 'smtp://1.2.3.4');
             done()
@@ -96,7 +96,7 @@ describe('do_qmd_response', function () {
 
     it('example.com: queue=undefined, forward', function (done) {
         this.plugin.cfg['example.com'] = { host: '1.2.3.4' }
-        this.plugin.do_qmd_response([OK, 'vpopmail forward'], this.connection.transaction, rcpt, (code, msg) => {
+        this.plugin.do_qmd_response([OK, 'vpopmail forward'], this.connection, rcpt, (code, msg) => {
             assert.equal(this.connection.transaction.notes.get('queue.wants'), undefined);
             assert.equal(this.connection.transaction.notes.get('queue.next_hop'), 'smtp://1.2.3.4');
             done()
@@ -105,7 +105,7 @@ describe('do_qmd_response', function () {
 
     it('example.com: queue=smtp_forward', function (done) {
         this.plugin.cfg['example.com'] = { host: '1.2.3.4', queue: 'smtp_forward' }
-        this.plugin.do_qmd_response([OK, 'vpopmail dir'], this.connection.transaction, rcpt, (code, msg) => {
+        this.plugin.do_qmd_response([OK, 'vpopmail dir'], this.connection, rcpt, (code, msg) => {
             assert.equal(this.connection.transaction.notes.get('queue.wants'), 'smtp_forward');
             assert.equal(this.connection.transaction.notes.get('queue.next_hop'), 'smtp://1.2.3.4');
             done()
@@ -115,7 +115,7 @@ describe('do_qmd_response', function () {
     it('example.com: next_hop=lmtp sets LMTP', function (done) {
         this.plugin.cfg.main.queue = 'smtp_forward'
         this.plugin.cfg['example.com'] = { host: '1.2.3.4', next_hop: 'lmtp://5.6.7.8' }
-        this.plugin.do_qmd_response([OK, 'vpopmail dir'], this.connection.transaction, rcpt, (code, msg) => {
+        this.plugin.do_qmd_response([OK, 'vpopmail dir'], this.connection, rcpt, (code, msg) => {
             assert.equal(this.connection.transaction.notes.get('queue.wants'), 'lmtp');
             assert.equal(this.connection.transaction.notes.get('queue.next_hop'), 'lmtp://5.6.7.8');
             done()
@@ -125,7 +125,7 @@ describe('do_qmd_response', function () {
     it('example.com: next_hop=lmtp + alias = smtp_forward', function (done) {
         this.plugin.cfg.main.queue = 'smtp_forward'
         this.plugin.cfg['example.com'] = { host: '1.2.3.4', next_hop: 'lmtp://5.6.7.8' }
-        this.plugin.do_qmd_response([OK, 'vpopmail alias'], this.connection.transaction, rcpt, (code, msg) => {
+        this.plugin.do_qmd_response([OK, 'vpopmail alias'], this.connection, rcpt, (code, msg) => {
             assert.equal(this.connection.transaction.notes.get('queue.wants'), 'smtp_forward');
             assert.equal(this.connection.transaction.notes.get('queue.next_hop'), 'lmtp://5.6.7.8');
             done()
@@ -134,7 +134,7 @@ describe('do_qmd_response', function () {
 
     it('example.com: queue=smtp_forward sets queue.wants & queue.next_hop', function (done) {
         this.plugin.cfg['example.com'] = { host: '1.2.3.4', queue: 'smtp_forward' }
-        this.plugin.do_qmd_response([OK, 'vpopmail dir'], this.connection.transaction, rcpt, (code, msg) => {
+        this.plugin.do_qmd_response([OK, 'vpopmail dir'], this.connection, rcpt, (code, msg) => {
             assert.equal(this.connection.transaction.notes.get('queue.wants'), 'smtp_forward');
             assert.equal(this.connection.transaction.notes.get('queue.next_hop'), 'smtp://1.2.3.4');
             done()
@@ -143,7 +143,7 @@ describe('do_qmd_response', function () {
 
     it('example.com: queue=lmtp sets queue.wants & queue.next_hop', function (done) {
         this.plugin.cfg['example.com'] = { host: '1.2.3.5', queue: 'lmtp' }
-        this.plugin.do_qmd_response([OK, 'vpopmail dir'], this.connection.transaction, rcpt, (code, msg) => {
+        this.plugin.do_qmd_response([OK, 'vpopmail dir'], this.connection, rcpt, (code, msg) => {
             assert.equal(this.connection.transaction.notes.get('queue.wants'), 'lmtp');
             assert.equal(this.connection.transaction.notes.get('queue.next_hop'), 'lmtp://1.2.3.5');
             done()
@@ -154,7 +154,7 @@ describe('do_qmd_response', function () {
         this.plugin.cfg['example.com'] = { host: '1.2.3.5', queue: 'lmtp' }
         this.connection.transaction.rcpt_to.push(new Address.Address('matt@other-domain.com'))
 
-        this.plugin.do_qmd_response([OK, 'vpopmail dir'], this.connection.transaction, rcpt, (code, msg) => {
+        this.plugin.do_qmd_response([OK, 'vpopmail dir'], this.connection, rcpt, (code, msg) => {
             assert.equal(this.connection.transaction.notes.get('queue.wants'), 'lmtp');
             assert.equal(this.connection.transaction.notes.get('queue.next_hop'), 'lmtp://1.2.3.5');
             done()
@@ -165,7 +165,7 @@ describe('do_qmd_response', function () {
         this.plugin.cfg['example.com'] = { host: '1.2.3.5', queue: 'lmtp' }
         this.connection.transaction.notes.set('queue.next_hop', 'smtp://2.3.4.5')
 
-        this.plugin.do_qmd_response([OK, 'vpopmail dir'], this.connection.transaction, rcpt, (code, msg) => {
+        this.plugin.do_qmd_response([OK, 'vpopmail dir'], this.connection, rcpt, (code, msg) => {
             assert.equal(this.connection.transaction.notes.get('queue.wants'), 'outbound');
             assert.equal(this.connection.transaction.notes.get('queue.next_hop'), undefined);
             done()

--- a/test/index.js
+++ b/test/index.js
@@ -10,11 +10,10 @@ const _set_up = function () {
     this.connection = new fixtures.connection.createConnection();
 };
 
-const _set_up_cfg = function () {
+function _set_up_cfg () {
     this.plugin = new fixtures.plugin('qmail-deliverable');
     this.connection = new fixtures.connection.createConnection();
     this.connection.transaction = new fixtures.transaction.createTransaction();
-    // this.connection.transaction.queue = {};
     this.plugin.register();
 };
 
@@ -23,7 +22,7 @@ describe('load_qmd_ini', function () {
 
     it('loads config', function () {
         this.plugin.load_qmd_ini();
-        assert.ok(this.plugin.cfg.main.check_outbound);
+        assert.ok(this.plugin.cfg.main.check_mail_from);
     })
 })
 
@@ -32,7 +31,7 @@ describe('register', function () {
 
     it('loads the config', function () {
         this.plugin.register();
-        assert.ok(this.plugin.cfg.main.check_outbound);
+        assert.ok(this.plugin.cfg.main.check_mail_from);
     })
     it('registers the mail hook', function () {
         this.plugin.register();
@@ -41,70 +40,137 @@ describe('register', function () {
     })
 })
 
-describe('get_next_hop', function () {
+describe('get_host', function () {
     beforeEach(_set_up)
 
-    it('wants_queue=empty sets smtp://', function () {
-        const testConfig = {
-            host: '1.2.3.5',
-        }
-        assert.equal(
-            this.plugin.get_next_hop(testConfig),
-            'smtp://1.2.3.5'
-        );
+    it('gets default host', function () {
+        this.plugin.cfg = { main: { host: undefined } }
+        assert.equal(this.plugin.get_host('example.com'), '127.0.0.1')
     })
-    it('wants_queue=lmtp sets lmtp://', function (done) {
-        const testConfig = {
-            host: '1.2.3.5',
-        }
-        assert.equal(
-            this.plugin.get_next_hop(testConfig, 'lmtp'),
-            'lmtp://1.2.3.5'
-        );
-        done()
+
+    it('gets main host', function () {
+        this.plugin.cfg = { main: { host: '127.1.1.1' } }
+        assert.equal(this.plugin.get_host('example.com'), '127.1.1.1')
     })
+
+    it('gets per-domain host', function () {
+        this.plugin.cfg = { main: { host: '127.1.1.1' }, 'example.com': { host: '127.2.2.2' }}
+        assert.equal(this.plugin.get_host('example.com'), '127.2.2.2')
+    })
+
 })
 
-describe('set_queue', function () {
+describe('do_qmd_response', function () {
     beforeEach(_set_up_cfg)
+    const rcpt = new Address.Address('<user@example.com>')
 
-    it('wants_queue=empty sets none', function (done) {
+    it('queue=undefined, dir', function (done) {
         this.plugin.cfg = {
-            'example.com': { host: '1.2.3.4' },
+            main: { host: '1.2.3.4' },
         }
-        assert.equal(
-            this.plugin.set_queue(this.connection, undefined, 'example.com'),
-            true
-        );
-        assert.equal(this.connection.transaction.notes.get('queue.wants'), undefined);
-        assert.equal(this.connection.transaction.notes.get('queue.next_hop'), undefined);
-        done()
+        this.plugin.do_qmd_response([OK, 'vpopmail dir'], this.connection.transaction, rcpt, (code, msg) => {
+            assert.equal(this.connection.transaction.notes.get('queue.wants'), undefined);
+            assert.equal(this.connection.transaction.notes.get('queue.next_hop'), 'smtp://1.2.3.4');
+            done()
+        })
     })
 
-    it('wants_queue=smtp_forward sets txn.notes.queue.wants & queue.next_hop', function (done) {
+    it('queue=undefined, alias', function (done) {
         this.plugin.cfg = {
-            'example.com': { host: '1.2.3.4' },
+            main: { host: '1.2.3.4' },
         }
-        assert.equal(
-            this.plugin.set_queue(this.connection, 'smtp_forward', 'example.com'),
-            true
-        );
-        assert.equal(this.connection.transaction.notes.get('queue.wants'), 'smtp_forward');
-        assert.equal(this.connection.transaction.notes.get('queue.next_hop'), 'smtp://1.2.3.4');
-        done()
+        this.plugin.do_qmd_response([OK, 'vpopmail alias'], this.connection.transaction, rcpt, (code, msg) => {
+            assert.equal(this.connection.transaction.notes.get('queue.wants'), undefined);
+            assert.equal(this.connection.transaction.notes.get('queue.next_hop'), 'smtp://1.2.3.4');
+            done()
+        })
     })
 
-    it('wants_queue=lmtp sets txn.queue.wants & queue.next_hop', function (done) {
-        this.plugin.cfg = {
-            'example.com': { host: '1.2.3.5' },
-        }
-        assert.equal(
-            this.plugin.set_queue(this.connection, 'lmtp', 'example.com'),
-            true
-        );
-        assert.equal(this.connection.transaction.notes.get('queue.wants'), 'lmtp');
-        assert.equal(this.connection.transaction.notes.get('queue.next_hop'), 'lmtp://1.2.3.5');
-        done()
+    it('example.com: queue=undefined, dir', function (done) {
+        this.plugin.cfg['example.com'] = { host: '1.2.3.4' }
+        this.plugin.do_qmd_response([OK, 'vpopmail dir'], this.connection.transaction, rcpt, (code, msg) => {
+            assert.equal(this.connection.transaction.notes.get('queue.wants'), undefined);
+            assert.equal(this.connection.transaction.notes.get('queue.next_hop'), 'smtp://1.2.3.4');
+            done()
+        })
+    })
+
+    it('example.com: queue=undefined, forward', function (done) {
+        this.plugin.cfg['example.com'] = { host: '1.2.3.4' }
+        this.plugin.do_qmd_response([OK, 'vpopmail forward'], this.connection.transaction, rcpt, (code, msg) => {
+            assert.equal(this.connection.transaction.notes.get('queue.wants'), undefined);
+            assert.equal(this.connection.transaction.notes.get('queue.next_hop'), 'smtp://1.2.3.4');
+            done()
+        })
+    })
+
+    it('example.com: queue=smtp_forward', function (done) {
+        this.plugin.cfg['example.com'] = { host: '1.2.3.4', queue: 'smtp_forward' }
+        this.plugin.do_qmd_response([OK, 'vpopmail dir'], this.connection.transaction, rcpt, (code, msg) => {
+            assert.equal(this.connection.transaction.notes.get('queue.wants'), 'smtp_forward');
+            assert.equal(this.connection.transaction.notes.get('queue.next_hop'), 'smtp://1.2.3.4');
+            done()
+        })
+    })
+
+    it('example.com: next_hop=lmtp sets LMTP', function (done) {
+        this.plugin.cfg.main.queue = 'smtp_forward'
+        this.plugin.cfg['example.com'] = { host: '1.2.3.4', next_hop: 'lmtp://5.6.7.8' }
+        this.plugin.do_qmd_response([OK, 'vpopmail dir'], this.connection.transaction, rcpt, (code, msg) => {
+            assert.equal(this.connection.transaction.notes.get('queue.wants'), 'lmtp');
+            assert.equal(this.connection.transaction.notes.get('queue.next_hop'), 'lmtp://5.6.7.8');
+            done()
+        })
+    })
+
+    it('example.com: next_hop=lmtp + alias = smtp_forward', function (done) {
+        this.plugin.cfg.main.queue = 'smtp_forward'
+        this.plugin.cfg['example.com'] = { host: '1.2.3.4', next_hop: 'lmtp://5.6.7.8' }
+        this.plugin.do_qmd_response([OK, 'vpopmail alias'], this.connection.transaction, rcpt, (code, msg) => {
+            assert.equal(this.connection.transaction.notes.get('queue.wants'), 'smtp_forward');
+            assert.equal(this.connection.transaction.notes.get('queue.next_hop'), 'lmtp://5.6.7.8');
+            done()
+        })
+    })
+
+    it('example.com: queue=smtp_forward sets queue.wants & queue.next_hop', function (done) {
+        this.plugin.cfg['example.com'] = { host: '1.2.3.4', queue: 'smtp_forward' }
+        this.plugin.do_qmd_response([OK, 'vpopmail dir'], this.connection.transaction, rcpt, (code, msg) => {
+            assert.equal(this.connection.transaction.notes.get('queue.wants'), 'smtp_forward');
+            assert.equal(this.connection.transaction.notes.get('queue.next_hop'), 'smtp://1.2.3.4');
+            done()
+        })
+    })
+
+    it('example.com: queue=lmtp sets queue.wants & queue.next_hop', function (done) {
+        this.plugin.cfg['example.com'] = { host: '1.2.3.5', queue: 'lmtp' }
+        this.plugin.do_qmd_response([OK, 'vpopmail dir'], this.connection.transaction, rcpt, (code, msg) => {
+            assert.equal(this.connection.transaction.notes.get('queue.wants'), 'lmtp');
+            assert.equal(this.connection.transaction.notes.get('queue.next_hop'), 'lmtp://1.2.3.5');
+            done()
+        })
+    })
+
+    it('example.com: split txn, 1st recipient', function (done) {
+        this.plugin.cfg['example.com'] = { host: '1.2.3.5', queue: 'lmtp' }
+        this.connection.transaction.rcpt_to.push(new Address.Address('matt@other-domain.com'))
+
+        this.plugin.do_qmd_response([OK, 'vpopmail dir'], this.connection.transaction, rcpt, (code, msg) => {
+            assert.equal(this.connection.transaction.notes.get('queue.wants'), 'lmtp');
+            assert.equal(this.connection.transaction.notes.get('queue.next_hop'), 'lmtp://1.2.3.5');
+            done()
+        })
+    })
+
+    it('example.com: split txn, different next_hop', function (done) {
+        this.plugin.cfg['example.com'] = { host: '1.2.3.5', queue: 'lmtp' }
+        this.connection.transaction.notes.set('queue.next_hop', 'smtp://2.3.4.5')
+
+        this.plugin.do_qmd_response([OK, 'vpopmail dir'], this.connection.transaction, rcpt, (code, msg) => {
+            assert.equal(this.connection.transaction.notes.get('queue.wants'), 'outbound');
+            assert.equal(this.connection.transaction.notes.get('queue.next_hop'), undefined);
+            done()
+        })
     })
 })
 
@@ -117,83 +183,83 @@ describe('get_qmd_response', function () {
     })
 })
 
-describe('check_qmd_response', function () {
+describe('decode_qmd_response', function () {
     beforeEach(_set_up)
 
     it('11', function () {
-        const r = this.plugin.check_qmd_response(this.connection, '11');
+        const r = this.plugin.decode_qmd_response(this.connection, '11');
         assert.equal(DENYSOFT, r[0]);
     })
     it('12', function () {
-        const r = this.plugin.check_qmd_response(this.connection, '12');
+        const r = this.plugin.decode_qmd_response(this.connection, '12');
         assert.equal(OK, r[0]);
     })
     it('13', function () {
-        const r = this.plugin.check_qmd_response(this.connection, '13');
+        const r = this.plugin.decode_qmd_response(this.connection, '13');
         assert.equal(OK, r[0]);
     })
     it('14', function () {
         this.connection.transaction = {
             mail_from: new Address.Address('<matt@example.com>'),
         };
-        let r = this.plugin.check_qmd_response(this.connection, '14');
+        let r = this.plugin.decode_qmd_response(this.connection, '14');
         assert.equal(OK, r[0]);
 
         this.connection.transaction.mail_from = new Address.Address('<>');
-        r = this.plugin.check_qmd_response(this.connection, '14');
+        r = this.plugin.decode_qmd_response(this.connection, '14');
         assert.equal(DENY, r[0]);
     })
     it('21', function () {
-        const r = this.plugin.check_qmd_response(this.connection, '21');
+        const r = this.plugin.decode_qmd_response(this.connection, '21');
         assert.equal(DENYSOFT, r[0]);
     })
     it('22', function () {
-        const r = this.plugin.check_qmd_response(this.connection, '22');
+        const r = this.plugin.decode_qmd_response(this.connection, '22');
         assert.equal(DENYSOFT, r[0]);
     })
     it('2f', function () {
-        const r = this.plugin.check_qmd_response(this.connection, '2f');
+        const r = this.plugin.decode_qmd_response(this.connection, '2f');
         assert.equal(DENYSOFT, r[0]);
     })
     it('f1', function () {
-        const r = this.plugin.check_qmd_response(this.connection, 'f1');
+        const r = this.plugin.decode_qmd_response(this.connection, 'f1');
         assert.equal(OK, r[0]);
     })
     it('f2', function () {
-        const r = this.plugin.check_qmd_response(this.connection, 'f2');
+        const r = this.plugin.decode_qmd_response(this.connection, 'f2');
         assert.equal(OK, r[0]);
     })
     it('f3', function () {
-        const r = this.plugin.check_qmd_response(this.connection, 'f3');
+        const r = this.plugin.decode_qmd_response(this.connection, 'f3');
         assert.equal(OK, r[0]);
     })
     it('f4', function () {
-        const r = this.plugin.check_qmd_response(this.connection, 'f4');
+        const r = this.plugin.decode_qmd_response(this.connection, 'f4');
         assert.equal(OK, r[0]);
     })
     it('f5', function () {
-        const r = this.plugin.check_qmd_response(this.connection, 'f5');
+        const r = this.plugin.decode_qmd_response(this.connection, 'f5');
         assert.equal(OK, r[0]);
     })
     it('f6', function () {
-        const r = this.plugin.check_qmd_response(this.connection, 'f6');
+        const r = this.plugin.decode_qmd_response(this.connection, 'f6');
         assert.equal(OK, r[0]);
     })
     it('fe', function () {
-        const r = this.plugin.check_qmd_response(this.connection, 'fe');
+        const r = this.plugin.decode_qmd_response(this.connection, 'fe');
         assert.equal(DENYSOFT, r[0]);
     })
     it('ff', function () {
-        const r = this.plugin.check_qmd_response(this.connection, 'ff');
+        const r = this.plugin.decode_qmd_response(this.connection, 'ff');
         assert.equal(DENY, r[0]);
     })
     it('0', function () {
-        const r = this.plugin.check_qmd_response(this.connection, '0');
+        const r = this.plugin.decode_qmd_response(this.connection, '0');
         assert.equal(DENY, r[0]);
         assert.equal('not deliverable', r[1]);
     })
     it('blah', function () {
-        const r = this.plugin.check_qmd_response(this.connection, 'blah');
+        const r = this.plugin.decode_qmd_response(this.connection, 'blah');
         assert.equal(undefined, r[0]);
     })
 })

--- a/test/index.js
+++ b/test/index.js
@@ -15,7 +15,7 @@ function _set_up_cfg () {
     this.connection = new fixtures.connection.createConnection();
     this.connection.transaction = new fixtures.transaction.createTransaction();
     this.plugin.register();
-};
+}
 
 describe('load_qmd_ini', function () {
     beforeEach(_set_up)


### PR DESCRIPTION
- fix: previously, would set next_hop=lmtp w/o setting q.wants=lmtp
- feat: also route via LMTP for local recipients when relaying
- cfg: rename check_outbound -> check_mail_from
- cfg: declare check_mail_from as boolean
- doc: added queue.wants & next_hop
- chore: much refactoring to simplify do_qmd_response
- chore: replace url.parse with new url.URL()
- chore: added many tests
